### PR TITLE
Add paragraph content and relation with page

### DIFF
--- a/api/pages/models/pages.settings.json
+++ b/api/pages/models/pages.settings.json
@@ -11,10 +11,6 @@
     "draftAndPublish": true
   },
   "attributes": {
-    "main_content": {
-      "type": "richtext",
-      "required": true
-    },
     "page_id": {
       "type": "string",
       "required": true,
@@ -41,6 +37,9 @@
       ],
       "plugin": "upload",
       "required": false
+    },
+    "paragraphs": {
+      "collection": "paragraphs"
     }
   }
 }

--- a/api/paragraphs/config/routes.json
+++ b/api/paragraphs/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/paragraphs",
+      "handler": "paragraphs.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/paragraphs/count",
+      "handler": "paragraphs.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/paragraphs/:id",
+      "handler": "paragraphs.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/paragraphs",
+      "handler": "paragraphs.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/paragraphs/:id",
+      "handler": "paragraphs.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/paragraphs/:id",
+      "handler": "paragraphs.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/paragraphs/controllers/paragraphs.js
+++ b/api/paragraphs/controllers/paragraphs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/paragraphs/models/paragraphs.js
+++ b/api/paragraphs/models/paragraphs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/paragraphs/models/paragraphs.settings.json
+++ b/api/paragraphs/models/paragraphs.settings.json
@@ -1,0 +1,22 @@
+{
+  "kind": "collectionType",
+  "collectionName": "paragraphs",
+  "info": {
+    "name": "paragraphs",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "heading": {
+      "type": "string"
+    },
+    "body": {
+      "type": "richtext",
+      "required": true
+    }
+  }
+}

--- a/api/paragraphs/services/paragraphs.js
+++ b/api/paragraphs/services/paragraphs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};


### PR DESCRIPTION
Add a paragraph content type which pages contain 'many of'. Paragraphs contain headings and bodies which will contain a content's section title and main content.